### PR TITLE
Use Python's importlib if it exists

### DIFF
--- a/django_webtest/__init__.py
+++ b/django_webtest/__init__.py
@@ -5,7 +5,12 @@ from django.core.handlers.wsgi import WSGIHandler
 from django.test import TestCase, TransactionTestCase
 from django.test.client import store_rendered_templates
 from django.utils.functional import curry
-from django.utils.importlib import import_module
+
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
+
 from django.core import signals
 try:
     from django.db import close_old_connections


### PR DESCRIPTION
Attempted use of django.utils.importlib generates a warning in Django 1.8 - this module will be removed in 1.9.

https://docs.djangoproject.com/en/1.8/releases/1.7/#django-utils-dictconfig-django-utils-importlib